### PR TITLE
AMRNAV-6504 Disable logging to files

### DIFF
--- a/gazebo_ros/launch/gzserver.launch.py
+++ b/gazebo_ros/launch/gzserver.launch.py
@@ -68,6 +68,9 @@ def generate_launch_description():
         LaunchConfiguration('params_file'),
         # This provides the trailing -- if a params_file is specified.
         _conditional_command('', LaunchConfiguration('params_file')),
+        _conditional_command("ros-args", LaunchConfiguration('ros_arguments')),
+        LaunchConfiguration('ros_arguments'),
+        _conditional_command('', LaunchConfiguration('ros_arguments')),
         LaunchConfiguration('extra_gazebo_args'),
     ]
 
@@ -173,7 +176,10 @@ def generate_launch_description():
             'params_file', default_value='',
             description='Path to ROS 2 yaml parameter file'
         ),
-
+        DeclareLaunchArgument(
+            'ros_arguments', default_value='',
+            description='Ros2 arguments'
+        ),
         # Specific to gazebo_ros
         DeclareLaunchArgument(
             'gdb', default_value='false',


### PR DESCRIPTION
Can't use existing arguments here unfortunately since we need to pass --ros-args and --disable-external-lib-logs
as separate arguments.
extra_gazebo_args puts it as one argument:
![Screenshot from 2024-03-14 13-28-22](https://github.com/pixel-robotics/gazebo_ros_pkgs/assets/87417416/e9a1c7bd-c515-4563-96a3-cf4337e16c83)




With change from this PR:

![Screenshot from 2024-03-14 13-26-32](https://github.com/pixel-robotics/gazebo_ros_pkgs/assets/87417416/de05a430-0dad-4d74-9aff-50859d8f843e)
